### PR TITLE
Requesting 'split_file_on_column' tool to be added

### DIFF
--- a/usegalaxy.org/text_processing/split_file_on_column/.shed.yml
+++ b/usegalaxy.org/text_processing/split_file_on_column/.shed.yml
@@ -1,0 +1,10 @@
+name: split_file_on_column
+owner: bgruening
+description: Split a file on a specific column.
+long_description: |
+    Split a file on a specific column.
+    Works like group, but every group is saved into a separate file.
+remote_repository_url: https://github.com/bgruening/galaxytools/tree/master/tools/text_processing/split_file_on_column
+type: unrestricted
+categories:
+- Text Manipulation


### PR DESCRIPTION
Requesting the 'split_file_on_column' tool to be added to Main for the Galaxy Training Academy. 

Link to tool in tool shed for reference: https://toolshed.g2.bx.psu.edu/repository?repository_id=0553ecd37c1a703b

TODO: Please replace this header with a description of your pull request.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
